### PR TITLE
Implemented various scenarios for mastership abitration

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -11,7 +11,7 @@ import (
 	"github.com/onosproject/onos-lib-go/pkg/northbound"
 )
 
-var log = logging.GetLogger()
+var log = logging.GetLogger("manager")
 
 // Config is a manager configuration
 type Config struct {

--- a/pkg/northbound/fabricsim/links.go
+++ b/pkg/northbound/fabricsim/links.go
@@ -31,11 +31,9 @@ func (s *Server) GetLink(ctx context.Context, request *simapi.GetLinkRequest) (*
 
 // AddLink creates and registers the specified simulated link
 func (s *Server) AddLink(ctx context.Context, request *simapi.AddLinkRequest) (*simapi.AddLinkResponse, error) {
-	log.Infof("Received add link request: %+v", request)
 	if _, err := s.simulation.AddLinkSimulator(request.Link); err != nil {
 		return nil, errors.Status(err).Err()
 	}
-	log.Infof("Sending add link response")
 	return &simapi.AddLinkResponse{}, nil
 }
 

--- a/pkg/simulator/core.go
+++ b/pkg/simulator/core.go
@@ -8,11 +8,14 @@ package simulator
 import (
 	simapi "github.com/onosproject/onos-api/go/onos/fabricsim"
 	"github.com/onosproject/onos-lib-go/pkg/errors"
+	"github.com/onosproject/onos-lib-go/pkg/logging"
 	p4api "github.com/p4lang/p4runtime/go/p4/v1"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"strings"
 	"sync"
 )
+
+var log = logging.GetLogger("simulator")
 
 // Simulation tracks all entities and activities related to device, host and link simulation
 type Simulation struct {

--- a/pkg/simulator/core.go
+++ b/pkg/simulator/core.go
@@ -9,6 +9,7 @@ import (
 	simapi "github.com/onosproject/onos-api/go/onos/fabricsim"
 	"github.com/onosproject/onos-lib-go/pkg/errors"
 	p4api "github.com/p4lang/p4runtime/go/p4/v1"
+	"google.golang.org/genproto/googleapis/rpc/code"
 	"strings"
 	"sync"
 )
@@ -47,11 +48,18 @@ type DeviceAgent interface {
 
 // StreamResponder is an abstraction for sending StreamResponse messages to controllers
 type StreamResponder interface {
-	// RecordMastershipArbitration records the given mastership arbitration and returns is
-	RecordMastershipArbitration(arbitration *p4api.MasterArbitrationUpdate) *p4api.MasterArbitrationUpdate
+	// LatchMastershipArbitration record the mastership arbitration role and election ID if the arbitration update is not nil
+	LatchMastershipArbitration(arbitration *p4api.MasterArbitrationUpdate) *p4api.MasterArbitrationUpdate
+
+	// SendMastershipArbitration sends a mastership arbitration message to the controller with OK code if
+	// the controller has the master election ID or with the given fail code otherwise
+	SendMastershipArbitration(role *p4api.Role, masterElectionID *p4api.Uint128, failCode code.Code)
 
 	// Send queues up the specified response to asynchronously sends on the backing stream
 	Send(response *p4api.StreamMessageResponse)
+
+	// IsMaster returns true if the responder is the current master, i.e. has the master election ID, for the given role.
+	IsMaster(role *p4api.Role, masterElectionID *p4api.Uint128) bool
 }
 
 type linkOrNIC struct {

--- a/pkg/simulator/device.go
+++ b/pkg/simulator/device.go
@@ -8,14 +8,11 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	simapi "github.com/onosproject/onos-api/go/onos/fabricsim"
-	"github.com/onosproject/onos-lib-go/pkg/logging"
 	p4api "github.com/p4lang/p4runtime/go/p4/v1"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"strconv"
 	"sync"
 )
-
-var log = logging.GetLogger("simulator", "device")
 
 // DeviceSimulator simulates a single device
 type DeviceSimulator struct {

--- a/pkg/simulator/device.go
+++ b/pkg/simulator/device.go
@@ -8,11 +8,9 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	simapi "github.com/onosproject/onos-api/go/onos/fabricsim"
-	"github.com/onosproject/onos-lib-go/pkg/errors"
 	"github.com/onosproject/onos-lib-go/pkg/logging"
 	p4api "github.com/p4lang/p4runtime/go/p4/v1"
 	"google.golang.org/genproto/googleapis/rpc/code"
-	"google.golang.org/genproto/googleapis/rpc/status"
 	"strconv"
 	"sync"
 )
@@ -99,8 +97,8 @@ func (ds *DeviceSimulator) DisablePort(id simapi.PortID, mode simapi.StopMode) e
 
 // RecordRoleElection checks the given election ID for the specified role and records it
 // if the given election ID is larger than a previously recorded election ID for the same
-// role. It returns error (if election for role not secured) and the latest election ID for the role.
-func (ds *DeviceSimulator) RecordRoleElection(role *p4api.Role, electionID *p4api.Uint128) (*p4api.Uint128, error) {
+// role; returns the winning election ID for the role
+func (ds *DeviceSimulator) RecordRoleElection(role *p4api.Role, electionID *p4api.Uint128) *p4api.Uint128 {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
@@ -112,39 +110,39 @@ func (ds *DeviceSimulator) RecordRoleElection(role *p4api.Role, electionID *p4ap
 	maxID, ok := ds.roleElections[roleID]
 	if !ok || isNewMaster(maxID, electionID) {
 		ds.roleElections[roleID] = electionID
-		return electionID, nil
+		return electionID
 	}
-	return maxID, errors.NewInvalid("Mastership for role %d has not been secured with election ID %d",
-		roleID, electionID)
+	return maxID
 }
 
 func isNewMaster(current *p4api.Uint128, new *p4api.Uint128) bool {
 	return current.High < new.High || (current.High == new.High && current.Low < new.Low)
 }
 
-// ProcessMastershipArbitration processes the specified arbitration update
-func (ds *DeviceSimulator) ProcessMastershipArbitration(arbitration *p4api.MasterArbitrationUpdate, responder StreamResponder) {
-	log.Debugf("Device %s: received mastership arbitration: %+v", ds.Device.ID, arbitration)
+// RunMastershipArbitration processes the specified arbitration update
+func (ds *DeviceSimulator) RunMastershipArbitration(role *p4api.Role, electionID *p4api.Uint128) {
+	log.Debugf("Device %s: running mastership arbitration for role %s and electionID %+v", ds.Device.ID, role, electionID)
 
-	electionStatus := &status.Status{Code: int32(code.Code_OK)}
-	maxElectionID, err := ds.RecordRoleElection(arbitration.Role, arbitration.ElectionId)
-	if err != nil {
-		electionStatus.Code = int32(code.Code_PERMISSION_DENIED)
-		electionStatus.Message = err.Error()
+	// Record the role and election ID, return the winning (highest) election ID for the role
+	maxElectionID := ds.RecordRoleElection(role, electionID)
+
+	ds.lock.RLock()
+	defer ds.lock.RUnlock()
+
+	// If we cannot locate the responder with the max election ID, then this means the previous
+	// master has left and we need to return NOT_FOUND code to all existing responders for this role
+	failCode := code.Code_NOT_FOUND
+	for _, r := range ds.responders {
+		if r.IsMaster(role, maxElectionID) {
+			failCode = code.Code_ALREADY_EXISTS
+			break
+		}
 	}
-	// Respond directly to the responder corresponding to the stream from where we received the message
-	responder.Send(&p4api.StreamMessageResponse{
-		Update: &p4api.StreamMessageResponse_Arbitration{
-			Arbitration: &p4api.MasterArbitrationUpdate{
-				DeviceId:   arbitration.DeviceId,
-				Role:       arbitration.Role,
-				ElectionId: maxElectionID,
-				Status:     electionStatus,
-			},
-		},
-	})
 
-	// FIXME: Respond to other stream responders as well
+	// Notify all responders for the role
+	for _, r := range ds.responders {
+		r.SendMastershipArbitration(role, maxElectionID, failCode)
+	}
 }
 
 // AddStreamResponder adds the given stream responder to the specified device

--- a/pkg/topo/loader.go
+++ b/pkg/topo/loader.go
@@ -8,11 +8,8 @@ import (
 	"context"
 	"fmt"
 	simapi "github.com/onosproject/onos-api/go/onos/fabricsim"
-	"github.com/onosproject/onos-lib-go/pkg/logging"
 	"google.golang.org/grpc"
 )
-
-var log = logging.GetLogger()
 
 // LoadTopology loads the specified YAML file and creates the prescribed simulated topology entities
 // using the fabric simulator API client.

--- a/pkg/topo/schema.go
+++ b/pkg/topo/schema.go
@@ -5,10 +5,13 @@
 package topo
 
 import (
+	"github.com/onosproject/onos-lib-go/pkg/logging"
 	"github.com/spf13/viper"
 	"os"
 	"path/filepath"
 )
+
+var log = logging.GetLogger("topo")
 
 // Topology is a description of a simulated network topology
 type Topology struct {


### PR DESCRIPTION
The implementation now notifies the winners with OK, loosers with ALREADY_FOUND and in case where the previous master stream for the role closes, all other controller streams (who previously lost the election for this role) will be notified with NOT_FOUND, allowing them to initiate a new election.